### PR TITLE
README.md: use markdown, add port 7814 explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,22 @@
 # Tauon Remote & Stream
-Tauon Remote & Stream Android Application, Remote & Stream Tauon Music Box on your Android Phone<br/>
+Tauon Remote & Stream Android Application: remotely control & stream music from [Tauon Music Box](http://tauonmusicbox.rocks/) to your Android Phone.
 
-<img src="https://raw.githubusercontent.com/sultannamja/tauonremote_android/main/screenshot/SS_TauonRemote-beta.png"/><p/>
+<img src="https://raw.githubusercontent.com/sultannamja/tauonremote_android/main/screenshot/SS_TauonRemote-beta.png"/>
 
-<h3>this is a beta version, the main function of the remote is completely done, it's just that there are still issues though it's not that bad.</h3>
+### This is a beta version: the main function of the remote is completely done, however there are still some issues (though not that bad).
 
-<h1>How to use</h1>
-<ul>
-  <li>Download and Install <a href="https://github.com/sultannamja/tauonremote_android/releases/download/v1.0-beta.3/TauonRemote.Stream_v1.0-beta3.apk">TauonRemote.Stream_v1.0-beta3.apk</a> to your Android Device...</li>
-  <li>Open <a href="https://github.com/Taiko2k/TauonMusicBox">Tauon Music Box</a> go to Settings-->Function-->Page 4-->Enable Remote Server.</li>
-  <li>Open Tauon Remote and enter your PC IP Address... then click Remote.</li>
-</ul>
+# How to use
 
-<h1>TODO List</h1>
-<ul>
-  <li><s>Notification Control.</s></li>
-  <li><s>Light Theme.</s></li>
-<li>Orientation Resize.</li>
-<li>Fixing Search.</li>
-<li>Fixing Played in Track,Album Track...</li>
-<li>Saved Album Track, Automatic Play.</li>
-<li>Reload Lyrics when Lyrics Added</li>
-</ul>
+* Download and Install <a href="https://github.com/sultannamja/tauonremote_android/releases/download/v1.0-beta.3/TauonRemote.Stream_v1.0-beta3.apk">TauonRemote.Stream_v1.0-beta3.apk</a> to your Android Device.
+* Open <a href="https://github.com/Taiko2k/TauonMusicBox">Tauon Music Box</a> go to Settings --> Function --> Page 4 --> Enable Remote Server.
+* Open Tauon Remote and enter the IP Address of the computer running Tauon Music Box, then click Remote.
+* *Optional*: open port 7814 (TCP) on your machine's firewall (cf. Tauon [wiki](https://github.com/Taiko2k/TauonMusicBox/wiki/Remote-Control-API))
+
+# TODO List
+- [x] ~~Notification Control~~
+- [x] ~~Light Theme~~
+- [ ] Orientation Resize
+- [ ] Fixing Search
+- [ ] Fixing Played in Track,Album Track…
+- [ ] Saved Album Track, Automatic Play
+- [ ] Reload Lyrics when Lyrics Added


### PR DESCRIPTION
- Turn README.md into an actual markdown document (instead of html)
- Add brief explanation regarding the port used by Tauon for the remote functionality
- Small rewrites